### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Environment/Native.php
+++ b/src/Environment/Native.php
@@ -7,7 +7,7 @@ namespace RoadRunner\VersionChecker\Environment;
 final class Native implements EnvironmentInterface
 {
     public function __construct(
-        private array $values = []
+        private array $values = [],
     ) {
         $this->values = $values + $_ENV + $_SERVER;
     }

--- a/src/Exception/UnsupportedVersionException.php
+++ b/src/Exception/UnsupportedVersionException.php
@@ -14,7 +14,7 @@ final class UnsupportedVersionException extends VersionCheckerException
     public function __construct(
         string $message,
         private string $installed,
-        private string $requested
+        private string $requested,
     ) {
         parent::__construct($message);
     }

--- a/src/Version/Comparator.php
+++ b/src/Version/Comparator.php
@@ -11,7 +11,7 @@ final class Comparator implements ComparatorInterface
 {
     private VersionParser $parser;
 
-    public function __construct(VersionParser $parser = null)
+    public function __construct(?VersionParser $parser = null)
     {
         $this->parser = $parser ?? new VersionParser();
     }
@@ -24,7 +24,7 @@ final class Comparator implements ComparatorInterface
     {
         return SemverComparator::greaterThanOrEqualTo(
             $this->parser->normalize($installed),
-            $this->parser->normalize($requested)
+            $this->parser->normalize($requested),
         );
     }
 
@@ -36,7 +36,7 @@ final class Comparator implements ComparatorInterface
     {
         return SemverComparator::lessThanOrEqualTo(
             $this->parser->normalize($installed),
-            $this->parser->normalize($requested)
+            $this->parser->normalize($requested),
         );
     }
 
@@ -48,7 +48,7 @@ final class Comparator implements ComparatorInterface
     {
         return SemverComparator::equalTo(
             $this->parser->normalize($installed),
-            $this->parser->normalize($requested)
+            $this->parser->normalize($requested),
         );
     }
 }

--- a/src/Version/Installed.php
+++ b/src/Version/Installed.php
@@ -27,9 +27,9 @@ final class Installed implements InstalledInterface
      * @param non-empty-string $executablePath
      */
     public function __construct(
-        ProcessInterface $process = null,
-        EnvironmentInterface $environment = null,
-        private string $executablePath = './rr'
+        ?ProcessInterface $process = null,
+        ?EnvironmentInterface $environment = null,
+        private string $executablePath = './rr',
     ) {
         $this->process = $process ?? new Process();
         $this->environment = $environment ?? new Native();
@@ -86,7 +86,7 @@ final class Installed implements InstalledInterface
                 ' If RoadRunner is installed in a different path, pass the correct `executablePath` parameter to the' .
                 ' `%s` class constructor.',
                 $this->executablePath,
-                self::class
+                self::class,
             ));
         }
 

--- a/src/Version/Required.php
+++ b/src/Version/Required.php
@@ -19,7 +19,7 @@ final class Required implements RequiredInterface
 
     private PackageInterface $package;
 
-    public function __construct(PackageInterface $package = null)
+    public function __construct(?PackageInterface $package = null)
     {
         $this->package = $package ?? new Package();
     }

--- a/src/VersionChecker.php
+++ b/src/VersionChecker.php
@@ -21,9 +21,9 @@ final class VersionChecker
     private ComparatorInterface $comparator;
 
     public function __construct(
-        InstalledInterface $installedVersion = null,
-        RequiredInterface $requiredVersion = null,
-        ComparatorInterface $comparator = null
+        ?InstalledInterface $installedVersion = null,
+        ?RequiredInterface $requiredVersion = null,
+        ?ComparatorInterface $comparator = null,
     ) {
         $this->installedVersion = $installedVersion ?? new Installed();
         $this->requiredVersion = $requiredVersion ?? new Required();
@@ -46,7 +46,7 @@ final class VersionChecker
         if (empty($version)) {
             throw new RequiredVersionException(
                 'Unable to determine required RoadRunner version.' .
-                ' Please specify the required version in the `$version` parameter.'
+                ' Please specify the required version in the `$version` parameter.',
             );
         }
 
@@ -56,7 +56,7 @@ final class VersionChecker
             throw new UnsupportedVersionException($this->getFormattedMessage(
                 'Installed RoadRunner version `%s` not supported. Requires version `%s` or higher.',
                 $installedVersion,
-                $version
+                $version,
             ), $installedVersion, $version);
         }
     }
@@ -75,7 +75,7 @@ final class VersionChecker
             throw new UnsupportedVersionException($this->getFormattedMessage(
                 'Installed RoadRunner version `%s` not supported. Requires version `%s` or lower.',
                 $installedVersion,
-                $version
+                $version,
             ), $installedVersion, $version);
         }
     }
@@ -94,7 +94,7 @@ final class VersionChecker
             throw new UnsupportedVersionException($this->getFormattedMessage(
                 'Installed RoadRunner version `%s` not supported. Requires version `%s`.',
                 $installedVersion,
-                $version
+                $version,
             ), $installedVersion, $version);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Issues        | [issues/39](https://github.com/roadrunner-php/issues/issues/39)
| Docs PR       | N/A

This PR resolves PHP 8.4 deprecation warnings related to implicitly nullable parameters.
It also applies `spiral/code-style` fixer for consistent formatting across affected classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved type clarity in several constructors by explicitly allowing nullable types.
	- Added trailing commas for consistency in parameter lists and method calls.
- **Style**
	- Minor formatting adjustments to exception messages for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->