### PR TITLE
chore: upgrade PHP to 8.1, add spiral/code-style, config and CI for code style, update psalm

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,22 +1,12 @@
-name: PHP-CS-Fixer Check
+on:
+    push:
+        branches:
+            - '*'
 
-on: [push, pull_request]
+name: Fix Code Style
 
 jobs:
-    phpcsfixer:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '8.1'
-
-            - name: Install dependencies
-              run: composer install --no-progress --no-suggest --prefer-dist
-
-            - name: Run PHP-CS-Fixer dry run
-              run: |
-                  vendor/bin/php-cs-fixer fix --dry-run -v --diff
+    cs-fix:
+        permissions:
+            contents: write
+        uses: spiral/gh-actions/.github/workflows/cs-fix.yml@master

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -1,14 +1,22 @@
-on:
-    pull_request: null
-    push:
-        branches:
-            - 1.x
+name: PHP-CS-Fixer Check
 
-name: coding-standards
+on: [push, pull_request]
 
 jobs:
-    psalm:
-        uses: spiral/gh-actions/.github/workflows/cs.yml@master
-        with:
-            os: >-
-                ['ubuntu-latest']
+    phpcsfixer:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.1'
+
+            - name: Install dependencies
+              run: composer install --no-progress --no-suggest --prefer-dist
+
+            - name: Run PHP-CS-Fixer dry run
+              run: |
+                  vendor/bin/php-cs-fixer fix --dry-run -v --diff

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,6 +13,6 @@ jobs:
             os: >-
                 ['ubuntu-latest']
             php: >-
-                ['8.1', '8.2', '8.3']
+                ['8.1', '8.2', '8.3', '8.4']
             stability: >-
                 ['prefer-lowest', 'prefer-stable']

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -13,6 +13,6 @@ jobs:
             os: >-
                 ['ubuntu-latest']
             php: >-
-                ['8.0', '8.1', '8.2', '8.3']
+                ['8.1', '8.2', '8.3']
             stability: >-
                 ['prefer-lowest', 'prefer-stable']

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs
 vendor
 node_modules
 .php-cs-fixer.cache
+/runtime/php-cs-fixer.cache

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ docs
 vendor
 node_modules
 .php-cs-fixer.cache
-/runtime/php-cs-fixer.cache
+/runtime

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,19 +2,11 @@
 
 declare(strict_types=1);
 
-if (!file_exists(__DIR__.'/src')) {
-    exit(0);
-}
+use Spiral\CodeStyle\Builder;
 
-return (new PhpCsFixer\Config())
-    ->setRules([
-        '@PSR12' => true,
-        'ternary_operator_spaces' => false,
-    ])
-    ->setRiskyAllowed(true)
-    ->setFinder(
-        (new PhpCsFixer\Finder())
-            ->in(__DIR__.'/src')
-            ->append([__FILE__])
-    )
-    ->setCacheFile('.php-cs-fixer.cache');
+require_once 'vendor/autoload.php';
+
+return Builder::create()
+    ->include(__DIR__ . '/src')
+    ->include(__FILE__)
+    ->build();

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,7 +6,12 @@ use Spiral\CodeStyle\Builder;
 
 require_once 'vendor/autoload.php';
 
+
 return Builder::create()
     ->include(__DIR__ . '/src')
     ->include(__FILE__)
-    ->build();
+    ->build()->setRules([
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'fully_qualified_strict_types' => true,
+        'no_unused_imports' => true,
+    ]);

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Make sure that your server is configured with following PHP version and extensions:
 
-- PHP 8.0+
+- PHP 8.1+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@
 [![Total Downloads](https://poser.pugx.org/roadrunner-php/version-checker/downloads)](https://packagist.org/roadrunner-php/version-checker/phpunit)
 <a href="https://discord.gg/8bZsjYhVVk"><img src="https://img.shields.io/badge/discord-chat-magenta.svg"></a>
 
-## Requirements
-
-Make sure that your server is configured with following PHP version and extensions:
-
-- PHP 8.1+
-
 ## Installation
 
 You can install the package via composer:

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,17 @@
     "homepage": "https://github.com/roadrunner-php/version-checker",
     "license": "MIT",
     "require": {
-        "php": "^8.0",
-        "symfony/process": "^5.4 || ^6.0 || ^7.0",
+        "php": "^8.1",
         "composer-runtime-api": "^2.0",
-        "composer/semver": "^3.3"
+        "composer/semver": "^3.3",
+        "symfony/process": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.8",
+        "phpcompatibility/php-compatibility": "^9.3",
         "phpunit/phpunit": "^9.6 || ^10.0",
-        "vimeo/psalm": "^5.9",
-        "friendsofphp/php-cs-fixer": "^3.8"
+        "spiral/code-style": "^2.2",
+        "vimeo/psalm": "^5.9"
     },
     "autoload": {
         "psr-4": {
@@ -32,7 +34,9 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "psalm": "vendor/bin/psalm --config=psalm.xml ./src",
-        "cs": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -vvv --dry-run --using-cache=no"
+        "cs": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -vvv --dry-run --using-cache=no",
+        "cs:diff": "php-cs-fixer fix --dry-run -v --diff",
+        "cs:fix": "php-cs-fixer fix -v"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,10 @@
         "symfony/process": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.8",
         "phpcompatibility/php-compatibility": "^9.3",
         "phpunit/phpunit": "^9.6 || ^10.0",
         "spiral/code-style": "^2.2",
-        "vimeo/psalm": "^5.9"
+        "vimeo/psalm": "^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -34,7 +33,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "psalm": "vendor/bin/psalm --config=psalm.xml ./src",
-        "cs": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -vvv --dry-run --using-cache=no",
         "cs:diff": "php-cs-fixer fix --dry-run -v --diff",
         "cs:fix": "php-cs-fixer fix -v"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "https://github.com/roadrunner-php/version-checker",
     "license": "MIT",
     "require": {
-        "php": "^8.1",
+        "php": ">=8.1",
         "composer-runtime-api": "^2.0",
         "composer/semver": "^3.3",
         "symfony/process": "^5.4 || ^6.0 || ^7.0"

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,11 +13,4 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-    <issueHandlers>
-        <UndefinedAttributeClass>
-            <errorLevel type="suppress">
-                <referencedClass name="JetBrains\PhpStorm\ExpectedValues" />
-            </errorLevel>
-        </UndefinedAttributeClass>
-    </issueHandlers>
 </psalm>

--- a/src/Composer/Package.php
+++ b/src/Composer/Package.php
@@ -11,8 +11,12 @@ final class Package implements PackageInterface
 {
     /**
      * @param non-empty-string $packageName
-     * @return non-empty-string[]
+     *
+     * @return string[]
+     *
+     * @psalm-return list<non-empty-string>
      */
+    #[\Override]
     public function getRequiredVersions(string $packageName): array
     {
         $versions = [];
@@ -20,13 +24,21 @@ final class Package implements PackageInterface
             $path = InstalledVersions::getInstallPath($package);
             if ($path !== null && \file_exists($path . '/composer.json')) {
                 /** @var array{require?: array<non-empty-string, non-empty-string>} $composerJson */
-                $composerJson = \json_decode(\file_get_contents($path . '/composer.json'), true);
+                $fileContent = \file_get_contents($path . '/composer.json');
+                /** @var array<string, mixed>|null $composerJson */
+                $composerJson = $fileContent === false ? null : \json_decode($fileContent, true);
 
-                if (
-                    isset($composerJson['require'][$packageName]) &&
-                    $this->isSupportedVersion($composerJson['require'][$packageName])
-                ) {
-                    $versions[] = $this->getMinVersion($composerJson['require'][$packageName]);
+                if (isset($composerJson['require'][$packageName])) {
+                    /** @var mixed $rawPackage */
+                    $rawPackage = $composerJson['require'][$packageName];
+
+                    if (is_string($rawPackage) && strlen($rawPackage) > 0) {
+                        assert($rawPackage !== '');
+
+                        if ($this->isSupportedVersion($rawPackage)) {
+                            $versions[] = $this->getMinVersion($rawPackage);
+                        }
+                    }
                 }
             }
         }

--- a/src/Environment/Native.php
+++ b/src/Environment/Native.php
@@ -15,6 +15,7 @@ final class Native implements EnvironmentInterface
     /**
      * @param non-empty-string $name
      */
+    #[\Override]
     public function get(string $name, mixed $default = null): mixed
     {
         return $this->values[$name] ?? $default;

--- a/src/Exception/RequiredVersionException.php
+++ b/src/Exception/RequiredVersionException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace RoadRunner\VersionChecker\Exception;
 
-final class RequiredVersionException extends VersionCheckerException
-{
-}
+final class RequiredVersionException extends VersionCheckerException {}

--- a/src/Exception/RoadrunnerNotInstalledException.php
+++ b/src/Exception/RoadrunnerNotInstalledException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace RoadRunner\VersionChecker\Exception;
 
-final class RoadrunnerNotInstalledException extends VersionCheckerException
-{
-}
+final class RoadrunnerNotInstalledException extends VersionCheckerException {}

--- a/src/Exception/UnsupportedVersionException.php
+++ b/src/Exception/UnsupportedVersionException.php
@@ -18,20 +18,4 @@ final class UnsupportedVersionException extends VersionCheckerException
     ) {
         parent::__construct($message);
     }
-
-    /**
-     * @return non-empty-string
-     */
-    public function getInstalledVersion(): string
-    {
-        return $this->installed;
-    }
-
-    /**
-     * @return non-empty-string
-     */
-    public function getRequestedVersion(): string
-    {
-        return $this->requested;
-    }
 }

--- a/src/Exception/VersionCheckerException.php
+++ b/src/Exception/VersionCheckerException.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace RoadRunner\VersionChecker\Exception;
 
-abstract class VersionCheckerException extends \Exception
-{
-}
+abstract class VersionCheckerException extends \Exception {}

--- a/src/Process/Process.php
+++ b/src/Process/Process.php
@@ -8,6 +8,7 @@ use Symfony\Component\Process\Exception\ProcessFailedException;
 
 final class Process implements ProcessInterface
 {
+    #[\Override]
     public function exec(array $command): string
     {
         $process = new \Symfony\Component\Process\Process($command);

--- a/src/Version/Comparator.php
+++ b/src/Version/Comparator.php
@@ -20,6 +20,7 @@ final class Comparator implements ComparatorInterface
      * @param non-empty-string $requested
      * @param non-empty-string $installed
      */
+    #[\Override]
     public function greaterThan(string $requested, string $installed): bool
     {
         return SemverComparator::greaterThanOrEqualTo(
@@ -32,6 +33,7 @@ final class Comparator implements ComparatorInterface
      * @param non-empty-string $requested
      * @param non-empty-string $installed
      */
+    #[\Override]
     public function lessThan(string $requested, string $installed): bool
     {
         return SemverComparator::lessThanOrEqualTo(
@@ -44,6 +46,7 @@ final class Comparator implements ComparatorInterface
      * @param non-empty-string $requested
      * @param non-empty-string $installed
      */
+    #[\Override]
     public function equal(string $requested, string $installed): bool
     {
         return SemverComparator::equalTo(

--- a/src/Version/Installed.php
+++ b/src/Version/Installed.php
@@ -42,16 +42,18 @@ final class Installed implements InstalledInterface
      */
     public function getInstalledVersion(): string
     {
-        if (!empty(self::$cachedVersion)) {
+        if (self::$cachedVersion != null) {
             return self::$cachedVersion;
         }
 
-        if (!empty(self::$cachedVersion = $this->getVersionFromEnv())) {
-            return self::$cachedVersion;
+        $version = $this->getVersionFromEnv();
+        if ($version != null) {
+            return self::$cachedVersion = $version;
         }
 
-        if (!empty(self::$cachedVersion = $this->getVersionFromConsoleCommand())) {
-            return self::$cachedVersion;
+        $version = $this->getVersionFromConsoleCommand();
+        if ($version != null) {
+            return self::$cachedVersion = $version;
         }
 
         throw new RoadrunnerNotInstalledException('Unable to determine RoadRunner version.');

--- a/src/Version/Installed.php
+++ b/src/Version/Installed.php
@@ -40,6 +40,7 @@ final class Installed implements InstalledInterface
      *
      * @throws RoadrunnerNotInstalledException
      */
+    #[\Override]
     public function getInstalledVersion(): string
     {
         if (self::$cachedVersion != null) {
@@ -60,9 +61,9 @@ final class Installed implements InstalledInterface
     }
 
     /**
-     * @return non-empty-string|null
+     * @return null|string
      */
-    private function getVersionFromEnv(): ?string
+    private function getVersionFromEnv(): string|null
     {
         /** @var string|null $version */
         $version = $this->environment->get(self::ENV_VARIABLE);
@@ -75,10 +76,11 @@ final class Installed implements InstalledInterface
     }
 
     /**
-     * @return non-empty-string|null
+     * @return null|string
+     *
      * @throws RoadrunnerNotInstalledException
      */
-    private function getVersionFromConsoleCommand(): ?string
+    private function getVersionFromConsoleCommand(): string|null
     {
         try {
             $output = $this->process->exec([$this->executablePath, '--version']);

--- a/src/Version/Required.php
+++ b/src/Version/Required.php
@@ -27,6 +27,7 @@ final class Required implements RequiredInterface
     /**
      * @return non-empty-string|null
      */
+    #[\Override]
     public function getRequiredVersion(): ?string
     {
         if (self::$cachedVersion !== null) {

--- a/src/VersionChecker.php
+++ b/src/VersionChecker.php
@@ -39,11 +39,11 @@ final class VersionChecker
      */
     public function greaterThan(?string $version = null): void
     {
-        if (empty($version)) {
+        if ($version == null) {
             $version = $this->requiredVersion->getRequiredVersion();
         }
 
-        if (empty($version)) {
+        if ($version == null) {
             throw new RequiredVersionException(
                 'Unable to determine required RoadRunner version.' .
                 ' Please specify the required version in the `$version` parameter.',
@@ -110,7 +110,7 @@ final class VersionChecker
     {
         \preg_match('/\bv?(\d+)\.(\d+)\.(\d+)\b/', $version, $matches);
 
-        if (!empty($matches[0])) {
+        if (isset($matches[0]) && $matches[0] != null) {
             $version = $matches[1] . '.' . $matches[2] . '.' . $matches[3];
         }
 

--- a/src/VersionChecker.php
+++ b/src/VersionChecker.php
@@ -114,7 +114,6 @@ final class VersionChecker
             $version = $matches[1] . '.' . $matches[2] . '.' . $matches[3];
         }
 
-        /** @var non-empty-string $msg */
         $msg = \sprintf($message, $installedVersion, $version);
 
         return $msg;


### PR DESCRIPTION
chore: upgrade PHP to 8.1, add spiral/code-style, config and CI for code style, update psalm

| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌
| New feature?  | ❌

This PR upgrades the minimum required PHP version to 8.1, adds spiral/code-style for consistent code formatting, includes a code style configuration file, and sets up CI to ensure code style checks are automatically enforced. Additionally, Psalm has been updated to the latest version to improve static analysis accuracy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new Composer scripts for code style checking and fixing.
- **Bug Fixes**
	- Updated PHP version requirements to 8.1+ in documentation and configuration files.
- **Chores**
	- Updated code style configuration and dependencies.
	- Improved .gitignore to exclude additional runtime files.
	- Adjusted GitHub Actions workflows for code style and testing.
	- Refined version checking logic for clearer condition handling.
	- Enhanced robustness in package version parsing and JSON handling.
	- Added explicit override annotations to multiple methods for clarity.
- **Style**
	- Simplified formatting of several exception class declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->